### PR TITLE
allow skip mailname configuration

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -12,6 +12,7 @@
     group: 'root'
     mode: '0644'
   notify: 'restart exim'
+  when: 'exim_skip_mailname is undefined or exim_skip_mailname == False'
 
 - name: 'Exim | Debian | Configure configuration variables.'
   become: yes


### PR DESCRIPTION
this commit allows the use of `exim_skip_mailname` to prevent this role from updating the mailname