### PR TITLE
Allow multiline 'ansible_managed' without breaking passwd.client

### DIFF
--- a/templates/passwd.client.j2
+++ b/templates/passwd.client.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 # password file used when the local exim is authenticating to a remote
 # host as a client.
 #


### PR DESCRIPTION
We use this role in an environment where users used to modify files managed by ansible because they overlooked the single line comment that `{{ ansible_managed }}` inserts by default. As a countermeasure we now use a huge text block spanning several lines to make this more clear.

This commit allows using `{{ ansible_managed }}` even if it spans multiple lines.
